### PR TITLE
add col for tei refer in tabellen, add draft tei templates

### DIFF
--- a/tabellen.md
+++ b/tabellen.md
@@ -2,407 +2,407 @@
 
 ## manuscripts
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|-|-|-|-|-|
-| id | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | – | Primärschlüssel |
-| title | VARCHAR(255) | INDEX | – | Kurztitel der Handschrift |
-| shelfmark | VARCHAR(255) | INDEX | – | Signatur innerhalb der Sammlung |
-| code | VARCHAR(255) | INDEX | – | Handschriftencode |
-| format | ENUM | – | – | Format des Codex (z.B. Quart, Folio) |
-| type | ENUM | – | – | Überlieferungsform (z.B. Codex, Fragment) |
-| codicological_description | TEXT | – | – | Kodikologische Beschreibung (z.B. Lagenformel) |
-| historical_description | TEXT | – | – | Freitext zur Überlieferungsgeschichte |
-| collection_id | BIGINT UNSIGNED | INDEX | collections | Zugehörige Sammlung |
-| created_at| DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname                  | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                      | TEI-msDesc                                                         |
+| ------------------------- | ------------------------------ | ------- | ------------ | ---------------------------------------------- | ------------------------------------------------------------------ |
+| id                        | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                | msDesc xml:id                                                      |
+| title                     | VARCHAR(255)                   | INDEX   | –            | Kurztitel der Handschrift                      | head->title                                                        |
+| shelfmark                 | VARCHAR(255)                   | INDEX   | –            | Signatur innerhalb der Sammlung                | msIdentifier->idno                                                 |
+| code                      | VARCHAR(255)                   | INDEX   | –            | Handschriftencode                              | msIdentifier ->idno @sortKey                                       |
+| format                    | ENUM                           | –       | –            | Format des Codex (z.B. Quart, Folio)           | physDesc->objectDesc->supportDesc->extent->dimensions->dim         |
+| type                      | ENUM                           | –       | –            | Überlieferungsform (z.B. Codex, Fragment)      | physDesc->objectDesc @form                                         |
+| codicological_description | TEXT                           | –       | –            | Kodikologische Beschreibung (z.B. Lagenformel) | physDesc->objectDesc->supportDesc->collation (formula)             |
+| historical_description    | TEXT                           | –       | –            | Freitext zur Überlieferungsgeschichte          | history->summary AND/OR history->origin , provenance, acquistition |
+| collection_id             | BIGINT UNSIGNED                | INDEX   | collections  | Zugehörige Sammlung                            | msIdentifier->repository @ref                                      |
+| created_at                | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                       | TEI-Header->publicationStmt->date                                  |
+| deleted_at                | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)           |                                                                    |
 
 ## parts
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|---------------|-------------------------------|---------|---------------|---------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| manuscript_id | BIGINT UNSIGNED | INDEX | manuscripts | Zugehörige Handschrift |
-| is_fragment | BOOLEAN | – | – | Kennzeichnung als Fragment (true/false) |
-| title | VARCHAR(255) | INDEX | – | Kennzeichnung des Teils oder Fragments (ehemals: part) |
-| folio | VARCHAR(255) | – | – | Freitextfeld für Blatt- oder Seitenangaben |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname      | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                              | TEI-msDesc                                                                    |
+| ------------- | ------------------------------ | ------- | ------------ | ------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| id            | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                        | msPart @xml:id                                                                |
+| manuscript_id | BIGINT UNSIGNED                | INDEX   | manuscripts  | Zugehörige Handschrift                                 | (msDesc @xml:id)                                                              |
+| is_fragment   | BOOLEAN                        | –       | –            | Kennzeichnung als Fragment (true/false)                | msPart->physDesc->objectDesc @form="fragment"                                 |
+| title         | VARCHAR(255)                   | INDEX   | –            | Kennzeichnung des Teils oder Fragments (ehemals: part) | msPart->msIdentifier->altIdentifier->idno                                     |
+| folio         | VARCHAR(255)                   | –       | –            | Freitextfeld für Blatt- oder Seitenangaben             | msPart->physDesc->objectDesc->supportDesc->extent->measure @type="leavesCount |
+| created_at    | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                               |                                                                               |
+| deleted_at    | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                   |                                                                               |
 
 ## texts
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|--------------------|-------------------------------|---------|---------------|------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| title | VARCHAR(255) | INDEX | – | Werktitel (Pflichtfeld) |
-| standard_identifier| VARCHAR(255) | INDEX | – | Normierter Identifier (z.B. BHL, BHG) (optional) |
-| comment | TEXT | – | – | Freitextkommentar zu Inhalt, Fassung oder Edition |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname            | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                         | TEI-index-texts |
+| ------------------- | ------------------------------ | ------- | ------------ | ------------------------------------------------- | --------------- |
+| id                  | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                   | bibl xml:id     |
+| title               | VARCHAR(255)                   | INDEX   | –            | Werktitel (Pflichtfeld)                           | bibl->title     |
+| standard_identifier | VARCHAR(255)                   | INDEX   | –            | Normierter Identifier (z.B. BHL, BHG) (optional)  | bibl->ref       |
+| comment             | TEXT                           | –       | –            | Freitextkommentar zu Inhalt, Fassung oder Edition | bibl->note      |
+| created_at          | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                          |                 |
+| deleted_at          | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)              |                 |
 
 ## text_witnesses
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|------------------|-------------------------------|---------|---------------|-----------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| text_id | BIGINT UNSIGNED | INDEX | texts | Verweis auf das überlieferte Werk |
-| part_id | BIGINT UNSIGNED | INDEX | parts | Verknüpfung zum entsprechenden Handschriftenteil |
-| transmission_type| ENUM | – | – | Art der Überlieferung: Abschrift, Bearbeitung, Auszug oder Urfassung |
-| comment | TEXT | – | – | Freitextkommentar zur Überlieferung |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname          | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                                            | TEI-msDesc(->msPart)                                    |
+| ----------------- | ------------------------------ | ------- | ------------ | -------------------------------------------------------------------- | ------------------------------------------------------- |
+| id                | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                                      | x                                                       |
+| text_id           | BIGINT UNSIGNED                | INDEX   | texts        | Verweis auf das überlieferte Werk                                    | x                                                       |
+| part_id           | BIGINT UNSIGNED                | INDEX   | parts        | Verknüpfung zum entsprechenden Handschriftenteil                     | msContents->msItem->filiation->ref @type"altMs" @target |
+| transmission_type | ENUM                           | –       | –            | Art der Überlieferung: Abschrift, Bearbeitung, Auszug oder Urfassung | msContents->msItem->filiation @type                     |
+| comment           | TEXT                           | –       | –            | Freitextkommentar zur Überlieferung                                  | msContents->msItem->filiation->note                     |
+| created_at        | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                                             | x                                                       |
+| deleted_at        | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                                 | x                                                       |
 
 ## initia
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|--------------|-------------------------------|---------|---------------|---------------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| manuscript_id | BIGINT UNSIGNED | INDEX | parts | Verknüpfung zur Handschrift |
-| text_id | BIGINT UNSIGNED | INDEX | texts | Optionaler Verweis auf zugeordnetes Werk |
-| position | INT | INDEX | - | Reihenfolge innerhalb der Handschrift |
-| incipit | TEXT | – | – | Beginn des Textabschnitts |
-| explicit | TEXT | – | – | Ende des Textabschnitts (optional) |
-| title | VARCHAR(255) | – | – | Optionaler Titel oder Titelvorspann |
-| folio | VARCHAR(255) | – | – | Seiten- oder Blattangabe (z.B. „24r–25v“) |
-| comment | TEXT | – | – | Freitextkommentar zur Einordnung oder Unsicherheiten |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) 
+| Feldname      | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                            | TEI-msDesc-msPart-msContents-msItem |
+| ------------- | ------------------------------ | ------- | ------------ | ---------------------------------------------------- | ----------------------------------- |
+| id            | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                      | msItem @xml:id                      |
+| manuscript_id | BIGINT UNSIGNED                | INDEX   | parts        | Verknüpfung zur Handschrift                          | x                                   |
+| text_id       | BIGINT UNSIGNED                | INDEX   | texts        | Optionaler Verweis auf zugeordnetes Werk             | msItem->title @ref                  |
+| position      | INT                            | INDEX   | -            | Reihenfolge innerhalb der Handschrift                | msItem @n                           |
+| incipit       | TEXT                           | –       | –            | Beginn des Textabschnitts                            | msItem->incipit                     |
+| explicit      | TEXT                           | –       | –            | Ende des Textabschnitts (optional)                   | msItem-> explicit                   |
+| title         | VARCHAR(255)                   | –       | –            | Optionaler Titel oder Titelvorspann                  | msItem->title                       |
+| folio         | VARCHAR(255)                   | –       | –            | Seiten- oder Blattangabe (z.B. „24r–25v“)            | msItem->locus                       |
+| comment       | TEXT                           | –       | –            | Freitextkommentar zur Einordnung oder Unsicherheiten | msItem->note                        |
+| created_at    | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                             |                                     |
+| deleted_at    | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                 |                                     |
 
 ## bindings
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|--------------------|-------------------------------|---------|----------------------|--------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| manuscript_id | BIGINT UNSIGNED | INDEX | manuscripts | Verknüpfte Handschrift |
-| style | ENUM | – | – | Stil des Einbands |
-| special_features | ENUM | – | – | Besondere Merkmale des Einbands |
-| is_restored | BOOLEAN | – | – | Kennzeichnung als restaurierter Einband |
-| has_fragments | BOOLEAN | – | – | Gibt an, ob Einbandfragmente enthalten sind |
-| workshop_id | BIGINT UNSIGNED | INDEX | bookbinders | Verknüpfung zur Buchbinderwerkstatt |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname         | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                   | TEI-msDesc-physDesc-bindingDesc                              |
+| ---------------- | ------------------------------ | ------- | ------------ | ------------------------------------------- | ------------------------------------------------------------ |
+| id               | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                             | @xml:id                                                      |
+| manuscript_id    | BIGINT UNSIGNED                | INDEX   | manuscripts  | Verknüpfte Handschrift                      |                                                              |
+| style            | ENUM                           | –       | –            | Stil des Einbands                           | bindingDesc->binding->p->term @style                         |
+| special_features | ENUM                           | –       | –            | Besondere Merkmale des Einbands             | bindingDesc->binding->p->term @special_features              |
+| is_restored      | BOOLEAN                        | –       | –            | Kennzeichnung als restaurierter Einband     | bindingDesc->binding->conditon->template text                |
+| has_fragments    | BOOLEAN                        | –       | –            | Gibt an, ob Einbandfragmente enthalten sind | physDesc->accMat->template text                              |
+| workshop_id      | BIGINT UNSIGNED                | INDEX   | bookbinders  | Verknüpfung zur Buchbinderwerkstatt         | bindingDesc->binding->p->ref @type="binding_workshop" target |
+| created_at       | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                    |                                                              |
+| deleted_at       | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)        |                                                              |
 
 ## digital_copies
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|-------------------|-------------------------------|---------|---------------|-------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| manuscript_id | BIGINT UNSIGNED | INDEX | manuscripts | Verknüpfung zur zugehörigen Handschrift |
-| iiif_manifest_url | TEXT | – | – | URL zum IIIF-Manifest |
-| thumbnail_url | TEXT | – | – | Direktlink zur ersten Seite (für Vorschaubildanzeige) |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname          | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                             | TEI-msDesc                                                                   |
+| ----------------- | ------------------------------ | ------- | ------------ | ----------------------------------------------------- | ---------------------------------------------------------------------------- |
+| id                | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                       |                                                                              |
+| manuscript_id     | BIGINT UNSIGNED                | INDEX   | manuscripts  | Verknüpfung zur zugehörigen Handschrift               |                                                                              |
+| iiif_manifest_url | TEXT                           | –       | –            | URL zum IIIF-Manifest                                 | additional->surrogates->listBibl->bibl @type="digital-facsimile"->ref target |
+| thumbnail_url     | TEXT                           | –       | –            | Direktlink zur ersten Seite (für Vorschaubildanzeige) | additional->surrogates->listBibl->bibl @type="thumbnail"->ref target         |
+| created_at        | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                              |                                                                              |
+| deleted_at        | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                  |                                                                              |
 
 ## literature
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|-----------------|-------------------------------|---------|---------------|--------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| is_uniform_title | BOOLEAN | – | – | Gibt an, ob es sich um einen Sachtitel handelt |
-| title | TEXT | – | – | Vollständiger Titel der Publikation |
-| year | INT(4) | – | – | Erscheinungsjahr |
-| short_title | VARCHAR(255) | INDEX | – | Kurzzitat zur internen Referenz (z.B. „Pächt 1969“) |
-| type | ENUM | – | – | Publikationstyp als Enum (z.B. „Katalog“, „Monographie“, „Artikel“) |
-| comment | TEXT | – | – | Anmerkungen zur Publikation |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname         | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                                           | TEI-listBibl-biblStruct                 |
+| ---------------- | ------------------------------ | ------- | ------------ | ------------------------------------------------------------------- | --------------------------------------- |
+| id               | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                                     | biblStruct @xml:id                      |
+| is_uniform_title | BOOLEAN                        | –       | –            | Gibt an, ob es sich um einen Sachtitel handelt                      | ?                                       |
+| title            | TEXT                           | –       | –            | Vollständiger Titel der Publikation                                 | biblStruct->monogr->title               |
+| year             | INT(4)                         | –       | –            | Erscheinungsjahr                                                    | biblStruct->monogr->imprint->date       |
+| short_title      | VARCHAR(255)                   | INDEX   | –            | Kurzzitat zur internen Referenz (z.B. „Pächt 1969“)                 | biblStruct->monogr->title @type="short" |
+| type             | ENUM                           | –       | –            | Publikationstyp als Enum (z.B. „Katalog“, „Monographie“, „Artikel“) | biblStruct @type                        |
+| comment          | TEXT                           | –       | –            | Anmerkungen zur Publikation                                         | biblStruct->monogr->imprint->note       |
+| created_at       | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                                            |                                         |
+| deleted_at       | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                                |                                         |
 
 ## page_numbers
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|---------------|-------------------------------|---------|---------------|--------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| manuscript_id | BIGINT UNSIGNED | INDEX | manuscripts | Verknüpfte Handschrift |
-| position | INT | INDEX | – | Reihenfolge der Einheit innerhalb der Zählfolge |
-| count | VARCHAR(20) | – | – | Gezählte Einheit (z.B. „12“, „I“, „I*“) |
-| unit | ENUM | – | – | Zähleinheit (Blatt oder Seite) |
-| comment | TEXT | – | – | Optionaler Kommentar oder Erläuterung |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname      | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                       |
+| ------------- | ------------------------------ | ------- | ------------ | ----------------------------------------------- |
+| id            | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                 |
+| manuscript_id | BIGINT UNSIGNED                | INDEX   | manuscripts  | Verknüpfte Handschrift                          |
+| position      | INT                            | INDEX   | –            | Reihenfolge der Einheit innerhalb der Zählfolge |
+| count         | VARCHAR(20)                    | –       | –            | Gezählte Einheit (z.B. „12“, „I“, „I\*“)        |
+| unit          | ENUM                           | –       | –            | Zähleinheit (Blatt oder Seite)                  |
+| comment       | TEXT                           | –       | –            | Optionaler Kommentar oder Erläuterung           |
+| created_at    | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                        |
+| deleted_at    | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)            |
 
 ## dimensions
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|----------------|-------------------------------|---------|---------------|---------------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| manuscript_id | BIGINT UNSIGNED | INDEX | manuscripts | Verknüpfte Handschrift |
-| length | SMALLINT UNSIGNED | – | – | Länge (in mm) |
-| width | SMALLINT UNSIGNED | – | – | Breite (in mm) |
-| is_approximate | BOOLEAN | – | – | Gibt an, ob es sich um eine ungefähre Angabe handelt |
-| is_fragment | BOOLEAN | – | – | Gibt an, ob sich die Maße auf ein Fragment beziehen |
-| comment | TEXT | – | – | Optionaler Freitextkommentar |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname       | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                            | TEI - msDesc-physDesc                                                  |
+| -------------- | ------------------------------ | ------- | ------------ | ---------------------------------------------------- | ---------------------------------------------------------------------- |
+| id             | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                      | x                                                                      |
+| manuscript_id  | BIGINT UNSIGNED                | INDEX   | manuscripts  | Verknüpfte Handschrift                               | x                                                                      |
+| length         | SMALLINT UNSIGNED              | –       | –            | Länge (in mm)                                        | physDesc->objectDesc->supportDesc->extent->dimensions->height          |
+| width          | SMALLINT UNSIGNED              | –       | –            | Breite (in mm)                                       | physDesc->objectDesc->supportDesc->extent->dimensions->width           |
+| is_approximate | BOOLEAN                        | –       | –            | Gibt an, ob es sich um eine ungefähre Angabe handelt | physDesc->objectDesc->supportDesc->extent->dimensions @rend="circa"    |
+| is_fragment    | BOOLEAN                        | –       | –            | Gibt an, ob sich die Maße auf ein Fragment beziehen  | physDesc->objectDesc->supportDesc->extent->dimensions @type="fragment" |
+| comment        | TEXT                           | –       | –            | Optionaler Freitextkommentar                         | physDesc->objectDesc->supportDesc->extent->note                        |
+| created_at     | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                             |                                                                        |
+| deleted_at     | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                 |                                                                        |
 
 ## materials
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|--------------------|-------------------------------|---------|---------------|-----------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| materialized_id | BIGINT UNSIGNED | INDEX | – | ID der verknüpften Entität (z.B. Handschrift oder Teil) |
-| materialized_type | VARCHAR(255) | INDEX | – | Typ der verknüpften Entität (z.B. `manuscript`, `part`) |
-| type | ENUM | – | – | Beschreibstoff als kontrolliertes Vokabular |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname          | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                               | TEI-msDesc-physDesc / msPart-physDesc                    |
+| ----------------- | ------------------------------ | ------- | ------------ | ------------------------------------------------------- | -------------------------------------------------------- |
+| id                | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                         |                                                          |
+| materialized_id   | BIGINT UNSIGNED                | INDEX   | –            | ID der verknüpften Entität (z.B. Handschrift oder Teil) |                                                          |
+| materialized_type | VARCHAR(255)                   | INDEX   | –            | Typ der verknüpften Entität (z.B. `manuscript`, `part`) |                                                          |
+| type              | ENUM                           | –       | –            | Beschreibstoff als kontrolliertes Vokabular             | supportDesc @material and supportDesc->support->material |
+| created_at        | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                                |                                                          |
+| deleted_at        | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                    |                                                          |
 
 ## scripts
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|--------------------|-------------------------------|---------|---------------|--------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| part_id | BIGINT UNSIGNED | INDEX | parts | Verknüpfung zum kodikologischen Teil |
-| script_type | ENUM | – | – | Schrifttyp (Enum: z.B. Textualis, Bastarda, Capitalis) |
-| notation_type | ENUM | – | – | Notationstyp (Enum: z.B. Neumen, Quadratnotation, Mensuralnotation) |
-| has_marginalia | BOOLEAN | – | – | Gibt an, ob Marginalien vorhanden sind |
-| has_glosses | BOOLEAN | – | – | Gibt an, ob Glossen vorhanden sind |
-| has_secret_script | BOOLEAN | – | – | Gibt an, ob Geheimschrift verwendet wurde |
-| comment | TEXT | – | – | Freitextkommentar zur Schriftbeschreibung |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname          | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                                           | TEI msDesc->mPart->physDesc->                           |
+| ----------------- | ------------------------------ | ------- | ------------ | ------------------------------------------------------------------- | ------------------------------------------------------- |
+| id                | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                                     | scriptDesc @xml:id                                      |
+| part_id           | BIGINT UNSIGNED                | INDEX   | parts        | Verknüpfung zum kodikologischen Teil                                |                                                         |
+| script_type       | ENUM                           | –       | –            | Schrifttyp (Enum: z.B. Textualis, Bastarda, Capitalis)              | scritDesc->scriptNote @script and ScriptNote->term @ref |
+| notation_type     | ENUM                           | –       | –            | Notationstyp (Enum: z.B. Neumen, Quadratnotation, Mensuralnotation) | musicNotation                                           |
+| has_marginalia    | BOOLEAN                        | –       | –            | Gibt an, ob Marginalien vorhanden sind                              | additions - template text for true values element term  |
+| has_glosses       | BOOLEAN                        | –       | –            | Gibt an, ob Glossen vorhanden sind                                  | additions - template text for true values element term  |
+| has_secret_script | BOOLEAN                        | –       | –            | Gibt an, ob Geheimschrift verwendet wurde                           | additions - template text for true values element term  |
+| comment           | TEXT                           | –       | –            | Freitextkommentar zur Schriftbeschreibung                           | scriptDesc->scriptNote->note                            |
+| created_at        | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                                            |                                                         |
+| deleted_at        | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                                |                                                         |
 
 ## book_decorations
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|--------------|-------------------------------|---------|---------------|--------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| part_id | BIGINT UNSIGNED | INDEX | parts | Verknüpfung zum kodikologischen Teil |
-| type | ENUM | – | – | Ausstattungskategorie (Enum: z.B. Miniaturen, Fleuronnée) |
-| comment | TEXT | – | – | Optionaler Freitextkommentar |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname   | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                                 | TEI decoDesc             |
+| ---------- | ------------------------------ | ------- | ------------ | --------------------------------------------------------- | ------------------------ |
+| id         | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                           |                          |
+| part_id    | BIGINT UNSIGNED                | INDEX   | parts        | Verknüpfung zum kodikologischen Teil                      |                          |
+| type       | ENUM                           | –       | –            | Ausstattungskategorie (Enum: z.B. Miniaturen, Fleuronnée) | decoDesc->decoNote @type |
+| comment    | TEXT                           | –       | –            | Optionaler Freitextkommentar                              | decoNote                 |
+| created_at | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                                  |                          |
+| deleted_at | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                      |                          |
 
 ## text_transmissions
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|-----------------|-------------------------------|---------|------------------|--------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| source_id | BIGINT UNSIGNED | INDEX | text_witnesses | Verweis auf die zugrundeliegende Textüberlieferung (Vorlage) |
-| target_id | BIGINT UNSIGNED | INDEX | text_witnesses | Verweis auf die abschreibende oder abhängige Textüberlieferung |
-| comment | TEXT | – | – | Kommentar zur Art der Abhängigkeit, Unsicherheiten oder Fragmentstatus |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung)
+| Feldname   | SQL-Datentyp                   | Index   | Referenziert   | Kommentar                                                              | TEI->msContents->msItem   |
+| ---------- | ------------------------------ | ------- | -------------- | ---------------------------------------------------------------------- | ------------------------- |
+| id         | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –              | Primärschlüssel                                                        | msItem->filiation @xml:id |
+| source_id  | BIGINT UNSIGNED                | INDEX   | text_witnesses | Verweis auf die zugrundeliegende Textüberlieferung (Vorlage)           |                           |
+| target_id  | BIGINT UNSIGNED                | INDEX   | text_witnesses | Verweis auf die abschreibende oder abhängige Textüberlieferung         |                           |
+| comment    | TEXT                           | –       | –              | Kommentar zur Art der Abhängigkeit, Unsicherheiten oder Fragmentstatus | msItem->filiation->note   |
+| created_at | DATETIME                       | –       | –              | Zeitpunkt der Erstellung                                               |                           |
+| deleted_at | DATETIME                       | INDEX   | –              | Soft delete (Zeitpunkt der Löschung)                                   |                           |
 
 ## bookbinders
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|--------------|-------------------------------|---------|----------------|--------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| title | VARCHAR(255) | INDEX | – | Bezeichnung der Buchbinderwerkstatt |
-| institution_id | BIGINT UNSIGNED | INDEX | institutions | Verknüpfung zu einer übergeordneten Institution (z.B. Kloster, Bibliothek) |
-| external_link | TEXT | – | – | Link zur Einbanddatenbank oder anderen externen Ressourcen |
-| comment | TEXT | – | – | Freitextkommentar zu Werkstatt, Quellenlage oder Unsicherheiten |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname       | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                                                  | TEI - listOrg @type="bookbindersr"                                                    |
+| -------------- | ------------------------------ | ------- | ------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| id             | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                                            | org @xml:id                                                                           |
+| title          | VARCHAR(255)                   | INDEX   | –            | Bezeichnung der Buchbinderwerkstatt                                        | org->orgName                                                                          |
+| institution_id | BIGINT UNSIGNED                | INDEX   | institutions | Verknüpfung zu einer übergeordneten Institution (z.B. Kloster, Bibliothek) | org->desc @type="relation"->listRelation->relation @name="parent_institution" @active |
+| external_link  | TEXT                           | –       | –            | Link zur Einbanddatenbank oder anderen externen Ressourcen                 | org->bibl->ref @target                                                                |
+| comment        | TEXT                           | –       | –            | Freitextkommentar zu Werkstatt, Quellenlage oder Unsicherheiten            | org->desc @type="comment"                                                             |
+| created_at     | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                                                   |                                                                                       |
+| deleted_at     | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                                       |                                                                                       |
 
 ## binding_decorations
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|--------------|-------------------------------|---------|---------------|--------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| binding_id | BIGINT UNSIGNED | INDEX | bindings | Verknüpfung zum Einband |
-| type | ENUM | – | – | Art des Schmucks (kontrolliertes Vokabular) |
-| comment | TEXT | – | – | Optionaler Freitextkommentar zur Ausprägung oder Technik |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname   | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                                | TEI - physDesc->bindingDesc->binding |
+| ---------- | ------------------------------ | ------- | ------------ | -------------------------------------------------------- | ------------------------------------ |
+| id         | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                          | binding->decoNote xml:id             |
+| binding_id | BIGINT UNSIGNED                | INDEX   | bindings     | Verknüpfung zum Einband                                  |                                      |
+| type       | ENUM                           | –       | –            | Art des Schmucks (kontrolliertes Vokabular)              | decoNote @type                       |
+| comment    | TEXT                           | –       | –            | Optionaler Freitextkommentar zur Ausprägung oder Technik | decoNote                             |
+| created_at | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                                 |                                      |
+| deleted_at | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                     |                                      |
 
 ## dates
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|-----------------|-------------------------------|---------|---------------|--------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| datable_id | BIGINT UNSIGNED | INDEX | – | ID der verknüpften Entität (z.B. Handschrift, Teil, Einband) |
-| datable_type | VARCHAR(255) | INDEX | – | Typ der verknüpften Entität (z.B. `manuscript`, `part`, `binding`) |
-| format | ENUM | – | – | Formatcode der Datierung (siehe unten) |
-| range_from | INT | – | – | Berechneter Datumsbeginn (Jahr) |
-| range_to | INT | – | – | Berechnetes Datumsende (Jahr) |
-| value_1 | INT | – | – | Erster Wert zur Datierung (z.. Jahrhundert oder Jahr) |
-| value_2 | INT | – | – | Zweiter Wert (z.B. Jahrhundert, Viertel etc.), ggf. NULL |
-| is_certain | BOOLEAN | – | – | Gibt an, ob die Datierung als gesichert gilt |
-| source | TEXT | – | – | Freitext zur Quelle der Datierung (z.B. „Hs. datiert (36v)“) |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname     | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                                          | TEI -date     |
+| ------------ | ------------------------------ | ------- | ------------ | ------------------------------------------------------------------ | ------------- |
+| id           | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                                    | @xml:id       |
+| datable_id   | BIGINT UNSIGNED                | INDEX   | –            | ID der verknüpften Entität (z.B. Handschrift, Teil, Einband)       |               |
+| datable_type | VARCHAR(255)                   | INDEX   | –            | Typ der verknüpften Entität (z.B. `manuscript`, `part`, `binding`) |               |
+| format       | ENUM                           | –       | –            | Formatcode der Datierung (siehe unten)                             | @type         |
+| range_from   | INT                            | –       | –            | Berechneter Datumsbeginn (Jahr)                                    | @from ?       |
+| range_to     | INT                            | –       | –            | Berechnetes Datumsende (Jahr)                                      | @to ?         |
+| value_1      | INT                            | –       | –            | Erster Wert zur Datierung (z.. Jahrhundert oder Jahr)              | @not_before ? |
+| value_2      | INT                            | –       | –            | Zweiter Wert (z.B. Jahrhundert, Viertel etc.), ggf. NULL           | @not_after ?  |
+| is_certain   | BOOLEAN                        | –       | –            | Gibt an, ob die Datierung als gesichert gilt                       | @cert         |
+| source       | TEXT                           | –       | –            | Freitext zur Quelle der Datierung (z.B. „Hs. datiert (36v)“)       | @resp         |
+| created_at   | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                                           |               |
+| deleted_at   | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                               |               |
 
 ## provenances
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|----------------------|-------------------------------|---------|---------------------------|---------------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| attribution_id | BIGINT UNSIGNED | INDEX | provenance_attributions | Verweis auf die zugehörige Provenienzzuordnung |
-| subject_id | BIGINT UNSIGNED | INDEX | – | ID der referenzierten Entität (z.B. Ort, Institution, Sammlung, Person) |
-| subject_type | VARCHAR(255) | INDEX | – | Typ der referenzierten Entität (z.B. `institution`, `place`, `person`) |
-| is_certain | BOOLEAN | – | – | Gibt an, ob es sich um eine gesicherte Zuordnung handelt |
-| comment | TEXT | – | – | Optionaler Freitextkommentar zur Einordnung oder zur Quellenlage |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname       | SQL-Datentyp                   | Index   | Referenziert            | Kommentar                                                               | TEI-msDesc->history             |
+| -------------- | ------------------------------ | ------- | ----------------------- | ----------------------------------------------------------------------- | ------------------------------- |
+| id             | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –                       | Primärschlüssel                                                         |                                 |
+| attribution_id | BIGINT UNSIGNED                | INDEX   | provenance_attributions | Verweis auf die zugehörige Provenienzzuordnung                          |                                 |
+| subject_id     | BIGINT UNSIGNED                | INDEX   | –                       | ID der referenzierten Entität (z.B. Ort, Institution, Sammlung, Person) | placeName/orgName/persName @ref |
+| subject_type   | VARCHAR(255)                   | INDEX   | –                       | Typ der referenzierten Entität (z.B. `institution`, `place`, `person`)  | placeName/orgName/persName      |
+| is_certain     | BOOLEAN                        | –       | –                       | Gibt an, ob es sich um eine gesicherte Zuordnung handelt                | @cert (low/high)                |
+| comment        | TEXT                           | –       | –                       | Optionaler Freitextkommentar zur Einordnung oder zur Quellenlage        | provenance->p                   |
+| created_at     | DATETIME                       | –       | –                       | Zeitpunkt der Erstellung                                                |                                 |
+| deleted_at     | DATETIME                       | INDEX   | –                       | Soft delete (Zeitpunkt der Löschung)                                    |                                 |
 
 ## provenance_attributions
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|--------------------|-------------------------------|---------|---------------|--------------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| attributable_id | BIGINT UNSIGNED | INDEX | – | ID des verknüpften Objekts (z.B. Handschrift, Teil) |
-| attributable_type | VARCHAR(255) | INDEX | – | Typ des verknüpften Objekts (z.B. `manuscript`, `part`) |
-| logic | ENUM | – | – | Verknüpfung mehrerer Provenienzstellen als kombinierend oder alternativ |
-| comment | TEXT | – | – | Freitextkommentar oder Beleg zur Zuordnung |
-| date_id | BIGINT UNSIGNED | – | dates | Optionale Verknüpfung zu einer zeitlichen Einordnung |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname          | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                                               | TEI-msDesc->history->provenance |
+| ----------------- | ------------------------------ | ------- | ------------ | ----------------------------------------------------------------------- | ------------------------------- |
+| id                | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                                         | provenance @xml:id              |
+| attributable_id   | BIGINT UNSIGNED                | INDEX   | –            | ID des verknüpften Objekts (z.B. Handschrift, Teil)                     |                                 |
+| attributable_type | VARCHAR(255)                   | INDEX   | –            | Typ des verknüpften Objekts (z.B. `manuscript`, `part`)                 |                                 |
+| logic             | ENUM                           | –       | –            | Verknüpfung mehrerer Provenienzstellen als kombinierend oder alternativ | ?                               |
+| comment           | TEXT                           | –       | –            | Freitextkommentar oder Beleg zur Zuordnung                              | provenance->p                   |
+| date_id           | BIGINT UNSIGNED                | –       | dates        | Optionale Verknüpfung zu einer zeitlichen Einordnung                    | provenance->date                |
+| created_at        | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                                                |                                 |
+| deleted_at        | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                                    |                                 |
 
 ## olims
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|------------------|-------------------------------|---------|---------------|----------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| manuscript_id | BIGINT UNSIGNED | INDEX | manuscripts | Verknüpfte Handschrift |
-| signature | VARCHAR(255) | – | – | Die überlieferte (alte) Signatur der Handschrift |
-| comment | TEXT | – | – | Optionaler Kommentar zur Einordnung, Quelle oder historischen Kontext |
-| attribution_id | BIGINT UNSIGNED | INDEX | – | ID der verknüpften Institution oder Sammlung |
-| attribution_type | VARCHAR(255) | INDEX | – | Typ der verknüpften Quelle (z.B. `institution`, `collection`) |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname         | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                                             | TEI-msDesc->msIdentifier->altIdentifier type="former" |
+| ---------------- | ------------------------------ | ------- | ------------ | --------------------------------------------------------------------- | ----------------------------------------------------- |
+| id               | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                                       | @xml:id                                               |
+| manuscript_id    | BIGINT UNSIGNED                | INDEX   | manuscripts  | Verknüpfte Handschrift                                                |                                                       |
+| signature        | VARCHAR(255)                   | –       | –            | Die überlieferte (alte) Signatur der Handschrift                      | altIdentifier->idno                                   |
+| comment          | TEXT                           | –       | –            | Optionaler Kommentar zur Einordnung, Quelle oder historischen Kontext | altIdentifier->note                                   |
+| attribution_id   | BIGINT UNSIGNED                | INDEX   | –            | ID der verknüpften Institution oder Sammlung                          | altIdentifier->repository                             |
+| attribution_type | VARCHAR(255)                   | INDEX   | –            | Typ der verknüpften Quelle (z.B. `institution`, `collection`)         |                                                       |
+| created_at       | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                                              |                                                       |
+| deleted_at       | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                                  |                                                       |
 
 ## people
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|--------------|-------------------------------|---------|---------------|-----------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| name | VARCHAR(255) | INDEX | – | Gebräuchlicher oder bibliographischer Name der Person |
-| gnd_number | VARCHAR(50) | INDEX | – | GND-Nummer für Normdatenverknüpfung |
-| biographical_description | TEXT | – | – | Optional: biographische Angaben, Lebensdaten, Herkunft etc. |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname                 | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                                   | TEI - index listPerson |
+| ------------------------ | ------------------------------ | ------- | ------------ | ----------------------------------------------------------- | ---------------------- |
+| id                       | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                             | person @xml:id         |
+| name                     | VARCHAR(255)                   | INDEX   | –            | Gebräuchlicher oder bibliographischer Name der Person       | person->persName       |
+| gnd_number               | VARCHAR(50)                    | INDEX   | –            | GND-Nummer für Normdatenverknüpfung                         | person->ptr @target    |
+| biographical_description | TEXT                           | –       | –            | Optional: biographische Angaben, Lebensdaten, Herkunft etc. | person->note           |
+| created_at               | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                                    |                        |
+| deleted_at               | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                        |                        |
 
 ## languages
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|--------------|-------------------------------|---------|---------------|------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| iso_code | VARCHAR(10) | UNIQUE | – | Normierter ISO-Sprachcode (z.B. `la`, `de`) |
-| name | VARCHAR(255) | INDEX | – | Klartextname der Sprache (z.B. „Latein“, „Deutsch“) |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname   | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                           | TEI-msDesc                     |
+| ---------- | ------------------------------ | ------- | ------------ | --------------------------------------------------- | ------------------------------ |
+| id         | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                     |                                |
+| iso_code   | VARCHAR(10)                    | UNIQUE  | –            | Normierter ISO-Sprachcode (z.B. `la`, `de`)         | msContents->textLang @mainLang |
+| name       | VARCHAR(255)                   | INDEX   | –            | Klartextname der Sprache (z.B. „Latein“, „Deutsch“) | msContents->textLang           |
+| created_at | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                            |                                |
+| deleted_at | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                |                                |
 
 ## places
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|--------------|-------------------------------|---------|---------------|-----------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| name | VARCHAR(255) | INDEX | – | Normierter Ortsname (z.B. „Wien“, „Salzburg“, „Cluny“) |
-| gnd_number | VARCHAR(50) | INDEX | – | GND-Identifier des Ortsdatensatzes |
-| comment | TEXT | – | – | Optionaler Freitextkommentar |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname   | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                              | TEI-listPlace                    |
+| ---------- | ------------------------------ | ------- | ------------ | ------------------------------------------------------ | -------------------------------- |
+| id         | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                        | place xml:id                     |
+| name       | VARCHAR(255)                   | INDEX   | –            | Normierter Ortsname (z.B. „Wien“, „Salzburg“, „Cluny“) | place->placeName                 |
+| gnd_number | VARCHAR(50)                    | INDEX   | –            | GND-Identifier des Ortsdatensatzes                     | place -> ptr @type="gnd" @target |
+| comment    | TEXT                           | –       | –            | Optionaler Freitextkommentar                           | place->note                      |
+| created_at | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                               |                                  |
+| deleted_at | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                   |                                  |
 
 ## institutions
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|--------------|-------------------------------|---------|---------------|------------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| name | VARCHAR(255) | INDEX | – | Normierter Name der Institution (z.B. „Stift Klosterneuburg“) |
-| gnd_number | VARCHAR(50) | INDEX | – | GND-Identifier der Körperschaft |
-| place_id | BIGINT UNSIGNED | INDEX | places | Verknüpfung zum Standort |
-| comment | TEXT | – | – | Optionaler Freitextkommentar |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname   | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                                     | TEI-listOrg                  |
+| ---------- | ------------------------------ | ------- | ------------ | ------------------------------------------------------------- | ---------------------------- |
+| id         | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                               | org @xml:id                  |
+| name       | VARCHAR(255)                   | INDEX   | –            | Normierter Name der Institution (z.B. „Stift Klosterneuburg“) | org->orgName                 |
+| gnd_number | VARCHAR(50)                    | INDEX   | –            | GND-Identifier der Körperschaft                               | org->ptr @type="gnd" @target |
+| place_id   | BIGINT UNSIGNED                | INDEX   | places       | Verknüpfung zum Standort                                      | org->placeName @ref          |
+| comment    | TEXT                           | –       | –            | Optionaler Freitextkommentar                                  | org->note                    |
+| created_at | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                                      |                              |
+| deleted_at | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                          |                              |
 
 ## iconclasses
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|------------------|-------------------------------|---------|---------------|--------------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| code | VARCHAR(50) | UNIQUE | – | Iconclass-Code (z.B. „11H“) |
-| title | VARCHAR(255) | INDEX | – | Bezeichnung der Bildkategorie (z.B. „Die Heilige Familie“) |
-| parent_id | BIGINT UNSIGNED | INDEX | iconclasses | Optional: Verweis auf übergeordnete Kategorie |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname   | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                                  | TEI-term @ref=SKOS URI |
+| ---------- | ------------------------------ | ------- | ------------ | ---------------------------------------------------------- | ---------------------- |
+| id         | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                            |                        |
+| code       | VARCHAR(50)                    | UNIQUE  | –            | Iconclass-Code (z.B. „11H“)                                |                        |
+| title      | VARCHAR(255)                   | INDEX   | –            | Bezeichnung der Bildkategorie (z.B. „Die Heilige Familie“) |                        |
+| parent_id  | BIGINT UNSIGNED                | INDEX   | iconclasses  | Optional: Verweis auf übergeordnete Kategorie              |                        |
+| created_at | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                                   |                        |
+| deleted_at | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                       |                        |
 
 ## collections
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|--------------|-------------------------------|---------|---------------|-----------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| institution_id| BIGINT UNSIGNED | INDEX | institutions | Verknüpfte Institution (z.B. Stift, Universitätsbibliothek) |
-| name | VARCHAR(255) | INDEX | – | Name der Sammlung (z.B. „Stiftsbibliothek“, „Diözesanarchiv“) |
-| email | VARCHAR(255) | – | – | Zentrale oder bestandsbezogene Kontaktadresse (optional) |
-| website | TEXT | – | – | Link zur offiziellen Webseite oder digitalen Präsenz |
-| description | TEXT | – | – | Freitext zur Sammlungsgeschichte, inhaltlichen Ausrichtung oder Besonderheiten |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname       | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                                                      | TEI-listOrg @type="collections"                                                       |
+| -------------- | ------------------------------ | ------- | ------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| id             | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                                                | org @xml:id                                                                           |
+| institution_id | BIGINT UNSIGNED                | INDEX   | institutions | Verknüpfte Institution (z.B. Stift, Universitätsbibliothek)                    | org->desc @type="relation"->listRelation->relation @name="parent_institution" @active |
+| name           | VARCHAR(255)                   | INDEX   | –            | Name der Sammlung (z.B. „Stiftsbibliothek“, „Diözesanarchiv“)                  | org->orgName                                                                          |
+| email          | VARCHAR(255)                   | –       | –            | Zentrale oder bestandsbezogene Kontaktadresse (optional)                       | org->desc @type="contact"->email                                                      |
+| website        | TEXT                           | –       | –            | Link zur offiziellen Webseite oder digitalen Präsenz                           | org->desc @type="contact"->ptr @type="website" @target                                |
+| description    | TEXT                           | –       | –            | Freitext zur Sammlungsgeschichte, inhaltlichen Ausrichtung oder Besonderheiten | org->desc                                                                             |
+| created_at     | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                                                       |                                                                                       |
+| deleted_at     | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                                           |                                                                                       |
 
 ## groups
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|--------------|-------------------------------|---------|---------------|------------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| title | VARCHAR(255) | INDEX | – | Titel der Sachgruppe (z.B. „Missale“, „Kirchenreformen im 15. Jahrhundert“) |
-| description | TEXT | – | – | Optionaler Freitext zur thematischen oder funktionalen Einordnung |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname    | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                                                   | TEI->history->summary->listRelations->relation |
+| ----------- | ------------------------------ | ------- | ------------ | --------------------------------------------------------------------------- | ---------------------------------------------- |
+| id          | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                                             | relation->desc->name @type="group" @xml:id     |
+| title       | VARCHAR(255)                   | INDEX   | –            | Titel der Sachgruppe (z.B. „Missale“, „Kirchenreformen im 15. Jahrhundert“) | relation->desc->name @type="group"             |
+| description | TEXT                           | –       | –            | Optionaler Freitext zur thematischen oder funktionalen Einordnung           | relation->desc-                                |
+| created_at  | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                                                    |                                                |
+| deleted_at  | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                                        |                                                |
 
 ## person_attributions
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|------------------|-------------------------------|---------|---------------|---------------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| attributable_id | BIGINT UNSIGNED | INDEX | – | ID der verknüpften Entität (z.B. Teil, Schrift, Ausstattung) |
-| attributable_type| VARCHAR(255) | INDEX | – | Typ der verknüpften Entität (z.B. `part`, `script`, `book_decorations`) |
-| person_id | BIGINT UNSIGNED | INDEX | people | Verknüpfte Person aus der zentralen Personentabelle |
-| role | ENUM | – | – | Funktionsbezeichnung der Person im jeweiligen Kontext |
-| is_certain | BOOLEAN | – | – | Gibt an, ob die Zuschreibung als gesichert gilt |
-| comment | TEXT | – | – | Freitextkommentar zur Attribution oder Quellenangabe |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname          | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                                               | TEI->jeweiliges Element->listRelations->relation |
+| ----------------- | ------------------------------ | ------- | ------------ | ----------------------------------------------------------------------- | ------------------------------------------------ |
+| id                | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                                         | relation @xml:id                                 |
+| attributable_id   | BIGINT UNSIGNED                | INDEX   | –            | ID der verknüpften Entität (z.B. Teil, Schrift, Ausstattung)            |                                                  |
+| attributable_type | VARCHAR(255)                   | INDEX   | –            | Typ der verknüpften Entität (z.B. `part`, `script`, `book_decorations`) |                                                  |
+| person_id         | BIGINT UNSIGNED                | INDEX   | people       | Verknüpfte Person aus der zentralen Personentabelle                     | relation @active                                 |
+| role              | ENUM                           | –       | –            | Funktionsbezeichnung der Person im jeweiligen Kontext                   | relation @name                                   |
+| is_certain        | BOOLEAN                        | –       | –            | Gibt an, ob die Zuschreibung als gesichert gilt                         | relation @cert (high/low)                        |
+| comment           | TEXT                           | –       | –            | Freitextkommentar zur Attribution oder Quellenangabe                    | relation->desc                                   |
+| created_at        | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                                                |                                                  |
+| deleted_at        | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                                    |                                                  |
 
 ## language_manuscripts
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|----------------|-------------------------------|---------|---------------|--------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| manuscript_id | BIGINT UNSIGNED | INDEX | manuscripts | Verknüpfte Handschrift |
-| language_id | BIGINT UNSIGNED | INDEX | languages | Zugeordnete Sprache aus der zentralen Sprachentabelle |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname      | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                             | TEI-msDesc-msContents->textLang |
+| ------------- | ------------------------------ | ------- | ------------ | ----------------------------------------------------- | ------------------------------- |
+| id            | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                       |
+| manuscript_id | BIGINT UNSIGNED                | INDEX   | manuscripts  | Verknüpfte Handschrift                                |
+| language_id   | BIGINT UNSIGNED                | INDEX   | languages    | Zugeordnete Sprache aus der zentralen Sprachentabelle |
+| created_at    | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                              |
+| deleted_at    | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                  |
 
 ## language_literature
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|---------------|-------------------------------|---------|---------------|--------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| literature_id | BIGINT UNSIGNED | INDEX | literatures | Verknüpfte Publikation (Literatur- oder Katalogeintrag) |
-| language_id | BIGINT UNSIGNED | INDEX | languages | Zugeordnete Sprache aus der zentralen Sprachentabelle |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname      | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                               |
+| ------------- | ------------------------------ | ------- | ------------ | ------------------------------------------------------- |
+| id            | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                         |
+| literature_id | BIGINT UNSIGNED                | INDEX   | literatures  | Verknüpfte Publikation (Literatur- oder Katalogeintrag) |
+| language_id   | BIGINT UNSIGNED                | INDEX   | languages    | Zugeordnete Sprache aus der zentralen Sprachentabelle   |
+| created_at    | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                                |
+| deleted_at    | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                    |
 
 ## literature_manuscripts
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|----------------|-------------------------------|---------|---------------|-------------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| manuscript_id | BIGINT UNSIGNED | INDEX | manuscripts | Verknüpfte Handschrift |
-| literature_id | BIGINT UNSIGNED | INDEX | literatures | Verknüpfte Publikation |
-| pages | VARCHAR(50) | – | – | Seitenzahl oder Seitenbereich des Bezugs |
-| external_link | TEXT | – | – | Optionaler Direktlink zur digitalen Quelle (z.B. PDF, Online-Edition) |
-| comment | TEXT | – | – | Optionaler Freitextkommentar zur Art des Bezugs oder spezifischen Stellen |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname      | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                                                 | TEI-msDesc->additional->listBibl |
+| ------------- | ------------------------------ | ------- | ------------ | ------------------------------------------------------------------------- | -------------------------------- |
+| id            | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                                           |
+| manuscript_id | BIGINT UNSIGNED                | INDEX   | manuscripts  | Verknüpfte Handschrift                                                    |
+| literature_id | BIGINT UNSIGNED                | INDEX   | literatures  | Verknüpfte Publikation                                                    |
+| pages         | VARCHAR(50)                    | –       | –            | Seitenzahl oder Seitenbereich des Bezugs                                  |
+| external_link | TEXT                           | –       | –            | Optionaler Direktlink zur digitalen Quelle (z.B. PDF, Online-Edition)     |
+| comment       | TEXT                           | –       | –            | Optionaler Freitextkommentar zur Art des Bezugs oder spezifischen Stellen |
+| created_at    | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                                                  |
+| deleted_at    | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                                      |
 
 ## group_manuscripts
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|------------------|-------------------------------|---------|----------------|---------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| manuscript_id | BIGINT UNSIGNED | INDEX | manuscripts | Verknüpfte Handschrift |
-| group_id | BIGINT UNSIGNED | INDEX | groups | Verknüpfte Sachgruppe |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname      | SQL-Datentyp                   | Index   | Referenziert | Kommentar                            | TEI->history->summary->listRelations |
+| ------------- | ------------------------------ | ------- | ------------ | ------------------------------------ | ------------------------------------ |
+| id            | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                      | relation @xml:id                     |
+| manuscript_id | BIGINT UNSIGNED                | INDEX   | manuscripts  | Verknüpfte Handschrift               | relation @type="ms_group"            |
+| group_id      | BIGINT UNSIGNED                | INDEX   | groups       | Verknüpfte Sachgruppe                | relation @name                       |
+| created_at    | DATETIME                       | –       | –            | Zeitpunkt der Erstellung             |                                      |
+| deleted_at    | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung) |                                      |
 
 ## iconclass_parts
 
-| Feldname | SQL-Datentyp | Index | Referenziert | Kommentar |
-|----------------|-------------------------------|---------|---------------|-----------------------------------------------------------------------------|
-| id | BIGINT UNSIGNED AUTO_INCREMENT| PRIMARY | – | Primärschlüssel |
-| part_id | BIGINT UNSIGNED | INDEX | parts | Verknüpfter Handschriftenteil |
-| iconclass_id | BIGINT UNSIGNED | INDEX | iconclasses | Zugeordneter Iconclass-Eintrag |
-| folio | VARCHAR(50) | – | – | Angabe eines Folios oder Seitenbereichs (z.B. „28r“, „3v–4r“) |
-| comment | TEXT | – | – | Optionaler Freitextkommentar zur Darstellung oder Interpretation |
-| created_at | DATETIME | – | – | Zeitpunkt der Erstellung |
-| deleted_at | DATETIME | INDEX | – | Soft delete (Zeitpunkt der Löschung) |
+| Feldname     | SQL-Datentyp                   | Index   | Referenziert | Kommentar                                                        | TEI-term @ref=SKOS URI |
+| ------------ | ------------------------------ | ------- | ------------ | ---------------------------------------------------------------- | ---------------------- |
+| id           | BIGINT UNSIGNED AUTO_INCREMENT | PRIMARY | –            | Primärschlüssel                                                  | -                      |
+| part_id      | BIGINT UNSIGNED                | INDEX   | parts        | Verknüpfter Handschriftenteil                                    | -                      |
+| iconclass_id | BIGINT UNSIGNED                | INDEX   | iconclasses  | Zugeordneter Iconclass-Eintrag                                   | -                      |
+| folio        | VARCHAR(50)                    | –       | –            | Angabe eines Folios oder Seitenbereichs (z.B. „28r“, „3v–4r“)    | -                      |
+| comment      | TEXT                           | –       | –            | Optionaler Freitextkommentar zur Darstellung oder Interpretation | -                      |
+| created_at   | DATETIME                       | –       | –            | Zeitpunkt der Erstellung                                         | -                      |
+| deleted_at   | DATETIME                       | INDEX   | –            | Soft delete (Zeitpunkt der Löschung)                             | -                      |

--- a/tei_templates/listBibl_template.xml
+++ b/tei_templates/listBibl_template.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
+	schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Manuscripta: Index Literature</title>
+         </titleStmt>
+         <publicationStmt>
+            <p>Publication Information</p>
+         </publicationStmt>
+         <sourceDesc>
+            <p>Information about the source</p>
+         </sourceDesc>
+      </fileDesc>
+  </teiHeader>
+  <text>
+      <body>
+         <listBibl>           
+            <biblStruct type="literature-type" xml:id="literature-id" xml:lang="">
+               <monogr>
+                  <title level="m">[literature-title]</title>
+                  <title type="short">[literature-short_title]</title>
+                  <editor><forename>Tony</forename><surname>Bernhardt</surname></editor>
+                  <imprint>
+                     <publisher></publisher>
+                     <date>[literature-year]</date>
+                     <note>[literature-comment]</note>
+                  </imprint>
+               </monogr>
+            </biblStruct>
+            <biblStruct type="literature-type" xml:id="literature-id-">
+               <analytic>
+                  <title level="a">[literature-title]</title>
+                  <title type="short">[literature-short_title]</title>
+                  <author><forename>Elaine</forename><surname>Treharne</surname></author>
+               </analytic>
+               <monogr>
+                  <title level="j">postmedieval: a journal of medieval cultural studies</title>
+                  <idno type="ISSN">2040-5979</idno>
+                  <imprint>
+                     <biblScope unit="volume">4</biblScope>
+                     <biblScope unit="issue">4</biblScope>
+                     <biblScope unit="page">465-478</biblScope>
+                     <date>2013</date>
+                     <note type="url">https://doi.org/10.1057/pmed.2013.36</note>
+                  </imprint>
+               </monogr>
+            </biblStruct>
+         </listBibl>
+      </body>
+  </text>
+</TEI>

--- a/tei_templates/listOrg_template.xml
+++ b/tei_templates/listOrg_template.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
+	schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Title</title>
+         </titleStmt>
+         <publicationStmt>
+            <p>Publication Information</p>
+         </publicationStmt>
+         <sourceDesc>
+            <p>Information about the source</p>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <listChange>
+            <change></change>
+         </listChange>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+
+<!--         from table 'institutions' -->
+         <listOrg type="institutions">
+            <org xml:id="institutions-id">
+               <name>[institutions-name]</name>
+               <placeName ref="#institutions-place_id">[places-name]</placeName><!--  ideally get the name from table 'places'-->
+            </org>
+         </listOrg>
+         <!--         from table 'bookbinders' -->
+         <listOrg type="bookbinders">
+            <org xml:id="bookbinders-id">
+               <orgName>[bookbinders-title]</orgName>
+               <desc type="relation">
+                  <listRelation>
+                     <relation active="bookbinders-institution_id" name="parent_institution"/>
+                  </listRelation>
+               </desc>    
+               <desc type="comment">[bookbinders-comment]</desc>
+               <bibl><ref target="bookbinders-external_link"></ref></bibl>
+            </org>
+         </listOrg>
+         <!--         from table 'collections' -->
+         <listOrg type="collections">
+            <org xml:id="collections-id">
+               <orgName>[collections-name]</orgName>
+               <desc type="relation">
+                  <listRelation>
+                     <relation active="collections-institution_id" name="parent_institution"/>
+                  </listRelation>                 
+               </desc>
+               <desc type="comment">[collections-description]</desc>
+               <desc type="contact">
+                  <email>[collections-email]</email>
+                  <ptr type="website" target="collections-website"/>
+               </desc>
+               <bibl><ref target="bookbinders-external_link"></ref></bibl>
+            </org>
+         </listOrg>
+      </body>
+   </text>
+</TEI>

--- a/tei_templates/listPerson_template.xml
+++ b/tei_templates/listPerson_template.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
+	schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Title</title>
+         </titleStmt>
+         <publicationStmt>
+            <p>Publication Information</p>
+         </publicationStmt>
+         <sourceDesc>
+            <p>Information about the source</p>
+         </sourceDesc>
+      </fileDesc>
+      <revisionDesc>
+         <listChange>
+            <change></change>
+         </listChange>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <listPerson>
+            <person xml:id="people-id">
+               <persName>[people-name]</persName>
+               <ptr type="gnd_number" target="people-gnd_number"/>
+               <note>[people-biographical_description ]</note>
+            </person>
+         </listPerson>
+      </body>
+   </text>
+</TEI>

--- a/tei_templates/listPlaces_template.xml
+++ b/tei_templates/listPlaces_template.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
+	schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Title</title>
+            </titleStmt>
+            <publicationStmt>
+                <p>Publication Information</p>
+            </publicationStmt>
+            <sourceDesc>
+                <p>Information about the source</p>
+            </sourceDesc>
+        </fileDesc>
+        <revisionDesc>
+            <listChange>
+                <change></change>
+            </listChange>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPlace>
+                <place xml:id="place_123">
+                    <placeName></placeName>
+                    <ptr type="gnd_number" target="gnd_number"/>
+                    <note></note>
+                </place>
+            </listPlace>
+        </body>
+    </text>
+</TEI>

--- a/tei_templates/list_texts_template.xml
+++ b/tei_templates/list_texts_template.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
+	schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Index texts</title>
+         </titleStmt>
+         <publicationStmt>
+            <p>Publication Information</p>
+         </publicationStmt>
+         <sourceDesc>
+            <p>Information about the source</p>
+         </sourceDesc>
+      </fileDesc>
+  </teiHeader>
+  <text>
+      <body>
+         <listBibl>            
+           <bibl xml:id="texts-id">
+            <title>[text-title]</title>
+            <author></author> <!--not sure where to get the author from-->
+            <ref>[texts-standard_identifier]</ref>
+            <note>[texts-comment]</note>            
+         </bibl>
+         </listBibl>
+      </body>
+  </text>
+</TEI>

--- a/tei_templates/msDesc_template.xml
+++ b/tei_templates/msDesc_template.xml
@@ -1,0 +1,311 @@
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.tei-c.org/ns/1.0 https://diglib.hab.de/rules/schema/mss/v1.0/cataloguing.xsd"
+    version="5" xml:lang="deu">
+    
+<!--    ######## references to the SQL tables in @ref first part for the table,  ######
+        ######## second part for the field, e.g. manuscripts-id points to table 'manuscripts', field 'id'   ########
+        ###################-->
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Beschreibung von Cod. 20</title>
+                <respStmt>
+                    <resp>Beschrieben durch </resp>
+                    <name type="person"></name>
+                </respStmt>
+            </titleStmt>
+            <editionStmt>
+                <edition>Digitale Ausgabe nach TEI P5</edition>
+                <respStmt>
+                    <resp>TEI-P5 konforme Kodierung durch </resp>
+                    <name type="person"></name>
+                    <name type="org">Österreichische Akademie der Wissenschaften</name>
+                </respStmt>
+            </editionStmt>
+            <publicationStmt>
+                <publisher>
+                    <name type="org">Österreichische Akademie der Wissenschaften</name>
+                    <ptr target="www.oeaw.ac.at"/>
+                </publisher>
+                <date when="2025" type="issued">2025</date>
+                <distributor></distributor>
+                <availability status="restricted">
+                    <licence target="http://creativecommons.org/licenses/by-sa/3.0/de/" notBefore="2013-03-01">
+                        <p>Dieses Dokument steht unter einer Creative Commons Namensnennung-Weitergabe unter gleichen Bedingungen 3.0 Österreich Lizenz (CC BY-SA 3.0 AT).</p>
+                        <p> (<ref target="https://creativecommons.org/licenses/by-sa/3.0/at/">Copyright Information</ref>)</p>
+                    </licence>
+                </availability>
+                <pubPlace>
+                    <!--<ptr type="purl" target="http://"/>-->
+                </pubPlace>
+            </publicationStmt>
+            <sourceDesc>
+                <p>
+                    <bibl><abbr>Haidinger 1983</abbr></bibl> mit Addenda und Corrigenda IMAFO, ÖAW.
+                </p>
+            </sourceDesc>
+        </fileDesc>
+        <!--<encodingDesc>
+           One could use classDecl for the ENUM fields - but it would be easier and cleaner to reference to external SKOS documents
+            <classDecl>
+                <taxonomy xml:id="decoration">
+                    <category xml:id="illuminiert">
+                        <catDesc>die hs ist illuminiert</catDesc>
+                    </category>
+                    <category xml:id="initialen">
+                        <catDesc></catDesc>
+                            <category xml:id="rankeninitialen">
+                                <catDesc></catDesc>
+                            </category>
+                            <category xml:id="figurliche_buchschmuck">
+                                <catDesc></catDesc>
+                            </category>
+                    </category>
+                </taxonomy>
+                <taxonomy xml:id="binding">
+                    <category xml:id="gotisch">
+                        <catDesc>gotischer Einband</catDesc>
+                    </category>
+                    <category xml:id="blindstempel">
+                        <catDesc>der Einband hat Blindstempel</catDesc>
+                    </category>
+                </taxonomy>
+            </classDecl>
+        </encodingDesc>-->
+    </teiHeader>
+    <text>
+        <body>
+            <msDesc xml:id="manuscripts-id" xml:lang="deu">
+                <msIdentifier>
+                    <settlement ref="#institution-place_id">[places-name]Klosterneuburg</settlement>
+                    <repository ref="#manuscripts-collection_id">[collections-name]Stiftsbibliothek</repository>
+                    <idno sortKey="manuscript-code">[manuscript-shelfmark]Cod. 20</idno>
+                    <altIdentifier xml:id="olims-id" type="former">
+                        <repository ref="olims-attribution_id"></repository>
+                        <idno>[olims-signature]</idno>
+                        <note>[olims-comment]</note>
+                    </altIdentifier>
+                </msIdentifier>
+                <head>
+                    <title>[manuscript-title]Augustinus</title>
+                    <note type="caption"><!--is there some caption or should one patch from different elements? Perg. ## Bl. ##×##. <origPlace></origPlace>, <origDate></origDate>--></note>
+                </head>
+                
+<!--       Every manuscript has at least one msPart and the content (text,initia) go to the specific msPart. Right? -->
+                <physDesc>                   
+                    <objectDesc form="codex"> <!-- @form = [manuscript-type]-->
+                        <supportDesc material="perg"><!-- @material = [material-type]-->
+                            <support>
+                                <material>[material-type]</material>
+                            </support>
+                            <extent>
+                                <measure type="leavesCount" quantity="1"></measure>
+                                <dimensions type="fragment" unit="mm" rend="circa">
+                                    <dim>[manuscript-format]</dim>
+                                    <height>[dimensions-length]</height>
+                                    <width>[dimensions-width]</width>
+                                </dimensions>
+                                <note>[dimensions-comment]</note>
+                            </extent>
+                            <collation> [manuscripts-codicological_description]
+                                 <!--Beispiel für Lagen: I + 8.IV<hi rend="sup">128</hi>-->                                 
+                            </collation>
+                        </supportDesc>
+                        <!--  ######   Don't see where to get data on layout ######
+                            <layoutDesc>
+                                <layout columns="1" writtenLines="39" > <!-\-   Schriftspiegel / Schriftraum inkl. -\->
+                                    <dimensions type="written" unit="mm" rend="circa">
+                                        <height></height>
+                                        <width></width>
+                                    </dimensions> 
+                                    <p>    <!-\-   Info zu Linierung inkl. Schema.  Zeilen Zahl. Spaltenzahl.  -\->  </p>                          
+                                </layout>                                
+                            </layoutDesc>-->
+                    </objectDesc>
+                    
+                    <scriptDesc>
+                        <scriptNote>
+           <!-- ####### from table 'person_attributions' model to be used in relavant TEI Elements (not only in scriptDesc) -->
+                            <listRelation>
+                                <relation xml:id="person_attributions-id" name="person_attributions-role" active="person_attributions-person_id" cert="low"> <!--    @cert="low" or "high" reading the boolean [person_attributions-is_certain]-->
+                                    <desc>[person_attributions-comment]</desc>
+                                </relation>
+                            </listRelation>
+                        </scriptNote>
+                    </scriptDesc>                    
+             <!--    #### table 'bindings' ####            -->  
+                    <bindingDesc xml:id="bindings-id">
+                        <binding notBefore="1441" notAfter="1460"><!--  Datentyp ENUM - kontroliertes Vokabular können als <term> getaggt werden mit @ref @target zu externen SKOS -->
+                            <p><placeName ref="places">Klosterneuburg</placeName>
+                                <term ref="skosURI-style">[bindings-style]</term>
+                                <term ref="skosURI-special_features">[bindings-special_features]</term>
+                                <ref type="skosURI-bindings-workshop" target="bindings-workshop_id">[bookbinders-]</ref>
+                            </p>
+                            <condition >[bindings-is_resored]</condition><!--  ???? some if/else to read the boolean and write some template text "Restauriert/Nicht restauriert" OR add to the schema @restaured with true false possible values ? -->
+                            <decoNote xml:id="binding_decorations-id" type="binding_decorations-type">[binding_decorations-comment]</decoNote>
+                        </binding>
+                    </bindingDesc>
+                    <accMat>
+                        <p><!-- Read field 'bindings-has_fragments', if true add some template text : "Insitu Fragmente vorhanden" ???    --></p>
+                    </accMat>
+                </physDesc>
+                <history>
+                    <summary>
+                        <p>[manuscripts->historical_description]</p>
+<!-- #### read table 'group_manuscripts' with table 'groups' ####-->
+                        <listRelation>
+                            <relation xml:id="group_manuscripts-id" type="ms_group" name="group_manuscripts-group_id" mutual="#pull-all-mss-from-this-group #i-am-another-ms-from-this-group">
+                                <desc>
+                                    <name type="group" xml:id="groups-id">[groups-title]</name>
+                                    <listRef>
+                                        <ref type="group_ms" target="manuscripts-id">[manuscripts-shelfmark]</ref>
+                                    </listRef>
+                                    [groups-description]                                    
+                                </desc>
+                            </relation>
+                        </listRelation>
+                    </summary>
+                    <origin>
+                        <p/>
+                    </origin>
+<!--                    ### read table 'provenances + provenance_attributions -->
+                    <provenance xml:id="provenances-id" cert="low">
+                        <placeName ref="provenances-subject_id"><!--   get place-name  --></placeName><!--  according to the provenances-subject_type use placeName/persName/orgName  -->
+                        <date>[provenance_attributions-date]</date>
+                        <p>[provenances-comment]</p>
+                        <p>[provenance_attributions-comment]</p>
+                    </provenance>                    
+                    <acquisition>
+                        <p/>
+                    </acquisition>
+                </history>
+     <!--        #### table 'digital_copies' -->
+                <additional>
+                    <surrogates>
+                        <listBibl>
+                            <bibl type="digital-facsimile">
+                                <ref target="digital_copies-iiif_manifest_url">
+                                    <title>IIIF-Manifest</title>
+                                </ref>
+                            </bibl>
+                            <bibl type="thumbnail">
+                                <ref target="digital_copies-thumbnail_url">
+                                </ref>
+                            </bibl>
+                        </listBibl>
+                    </surrogates>             
+                    <listBibl>
+                        <bibl/>                            
+                    </listBibl>
+                </additional>
+<!--    ####  table 'parts'####            -->
+                <msPart xml:id="parts-id">
+                    <msIdentifier>
+                        <altIdentifier type="partial">
+                            <idno>[parts-title]</idno>
+                        </altIdentifier>
+                    </msIdentifier>
+    <!--  ### texts and text_witnesses are linked to parts not the whole ms so they come here ####  -->
+                    <msContents>
+                        <textLang mainLang="la">[languages-name]</textLang> <!--@mainLang = [languages-iso_code]-->
+                        <!--                    Table: initia. Get all initia with property manuscript_id === current part(!). For each map: -->
+                        <msItem xml:id="initia-id" n="[initia-position]">
+                            <locus rend="[page_numbers-unit]">[initia-folio]</locus>   
+                            <!-- maybe also <locusgrp><locus>1r</locus><locus>3v</locus></locusGrp> for cases where there are several folio entries: "1r, 3v"?                -->
+                            <!-- Table page_numbers - Ivana give up :) ... -->
+                            <title ref="#initia-text_id">[initia-title]</title><!--   #### the ref match the id in the index 'Texts'. -->                            
+                            <rubric></rubric> <!--Are there no rubrics?-->
+                            <incipit>[initia-incipit]</incipit>
+                            <explicit>[initia-explicit]</explicit>
+                            <finalRubric></finalRubric>
+                            <decoNote type="initial">
+                                <term></term>
+                            </decoNote>
+                            <listBibl>
+                                <bibl><abbr></abbr></bibl>
+                            </listBibl>
+                            <note>[initia-note]</note>  
+                            <!--  From table text_witnesses get entries which reference this text AND this ms (has the property text_id === current text_id and part_id)
+            check if this text_witness is in table 'text_transmissions' if so 
+                        for each entry make element <filiation> -> referencing the other witness (if the current msItem is the source take the target and vice versa)
+                        <ref> take the respective part and manuscript for display 
+                        use the  [text_witnesses-transmission_type] to set @type to filiation               
+        -->
+                            <filiation xml:id="text_tranismission-id" type="[text_witnesses-transmission_type]"> 
+                                <ref type="altMs" target="text_witnesses-part_id">[manuscripts-shelfmark + parts-title]: [text_witnesses-transmission_type]</ref>
+                                <note>[text_witnesses-comment]</note>  
+                                <note>[text_transmissions-comment]</note>
+                            </filiation> 
+                        </msItem>
+                         
+                    </msContents>
+                    <physDesc>                   
+                        <objectDesc form="fragment"> <!-- read table parts-is_fragment true => @form="fragment", false="fascicle" -->
+                            <supportDesc material="perg"><!-- @material = [material-type]-->
+                                <support>
+                                    <material>[material-type]</material>
+                                </support>
+                                <extent>
+                                    <measure type="leavesCount">[parts-folio]</measure>
+                                    <dimensions type="fragment" unit="mm" rend="circa">
+                                        <height>[dimensions-length]</height>
+                                        <width>[dimensions-width]</width>
+                                    </dimensions>
+                                    <note>[dimensions-comment]</note>
+                                </extent>
+                            </supportDesc>
+                  <!--  ######   Don't see where to get data on layout ######
+                            <layoutDesc>
+                                <layout columns="1" writtenLines="39" > <!-\-   Schriftspiegel / Schriftraum inkl. -\->
+                                    <dimensions type="written" unit="mm" rend="circa">
+                                        <height></height>
+                                        <width></width>
+                                    </dimensions> 
+                                    <p>    <!-\-   Info zu Linierung inkl. Schema.  Zeilen Zahl. Spaltenzahl.  -\->  </p>                          
+                                </layout>                                
+                            </layoutDesc>-->
+                        </objectDesc>
+                        
+                 <!--  ######   Table 'scripts' ###### -->       
+                        <scriptDesc xml:id="scripts-id">
+                            <scriptNote script="carolmin"><!-- @script = [scripts-script_type]-->
+                                <p><term ref="#SKOS-URI-script_type">[scripts-script_type]</term>.</p> <!--  Schriftarten ist ein kontroliertes Vokabular; können als <term> getaggt werden, und weiter zu externen SKOS oder hier in TEI-Header <classDecl> -> <taxonomy> -> <category> referenziert werden. -->
+                                <note>[scripts-comment</note>
+                                <!-- from table 'person_attributions' model to be used in relavant TEI Elements (not only in scriptDesc) -->
+                                <listRelation>
+                                    <relation xml:id="person_attributions-id1" name="person_attributions-role" active="person_attributions-person_id" cert="low"> <!--    @cert="low" or "high" reading the boolean [person_attributions-is_certain]-->
+                                        <desc>[person_attributions-comment]</desc>
+                                    </relation>
+                                </listRelation>
+                            </scriptNote>
+                        </scriptDesc>
+                        <musicNotation>
+                            [scripts-notation_type]
+                        </musicNotation>
+                        <decoDesc xml:id="book_decorations-id">                       
+                            <decoNote type="book_decorations-type">[book_decorations-comment]</decoNote>                       
+                        </decoDesc>
+                        <additions>
+                            <!--   ###### read the booleans from table scripts has_marginali, has_glosses and has_secret_Script , write template text "Enthält marginalia/glossen/geheimschriften" -->
+                            Enthält <term ref="gloss">Glossen</term> 
+                        </additions>                      
+                       
+                    </physDesc>
+                    <history>
+                       
+                 <!--         ###  table 'provenances + provenance_attributions -->
+                        <provenance xml:id="provenances-id1" cert="low">
+                            <placeName ref="provenances-subject_id"><!--   get place-name  --></placeName><!--  according to the provenances-subject_type use placeName/persName/orgName  -->
+                            <date>[provenance_attributions-date]</date>
+                            <p>[provenances-comment]</p>
+                            <p>[provenance_attributions-comment]</p>
+                        </provenance>                    
+                        <acquisition>
+                            <p/>
+                        </acquisition>
+                    </history>
+                </msPart>
+            </msDesc>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
Tried to find a matching TEI element or @attr for the SQL fields (see 'tabellenmd'). Plotted the fields to a template tei (`<msDesc>`). 
Each manuscript is one` TEI-msDesc`. All can be joined in  a `<teiCorpus>`.
Entities should ideally be in separate indices see the draft proposals using TEI `<listPlace`, `<listPerson`, `<listOrg>`, and the general `<list>` for texts.
References to control vocabularies (e.g. decorations) can be made using `<ref type="decoSKOS" target="SKOS-URI">` pointing to a SKOS URI.